### PR TITLE
use BitSet for ModuleKey

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ regex-syntax = "0.6"
 thiserror = "1.0"
 codespan-reporting = "0.11"
 data-encoding = "2.3.2"
+bit-set = "0.5"
 
 # required for prune only
 serde = { version = "1", optional = true }

--- a/src/compose/mod.rs
+++ b/src/compose/mod.rs
@@ -96,6 +96,7 @@
 ///
 /// codespan reporting for errors is available using the error `emit_to_string` method. this requires validation to be enabled, which is true by default. `Composer::non_validating()` produces a non-validating composer that is not able to give accurate error reporting.
 ///
+use bit_set::BitSet;
 use codespan_reporting::{
     diagnostic::{Diagnostic, Label},
     files::SimpleFile,
@@ -142,18 +143,18 @@ impl From<ShaderType> for ShaderLanguage {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
-struct ModuleKey(usize);
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+struct ModuleKey(BitSet);
 
 impl ModuleKey {
     fn from_members(key: &HashSet<String>, universe: &[String]) -> Self {
-        ModuleKey(universe.iter().enumerate().fold(0, |acc, (index, item)| {
+        let mut acc = BitSet::new();
+        for (index, item) in universe.iter().enumerate() {
             if key.contains(item) {
-                acc + (1 << index)
-            } else {
-                acc
+                acc.insert(index);
             }
-        }))
+        }
+        ModuleKey(acc)
     }
 }
 

--- a/src/compose/test.rs
+++ b/src/compose/test.rs
@@ -55,6 +55,50 @@ mod test {
     }
 
     #[test]
+    fn big_shaderdefs() {
+        let mut composer = Composer::default();
+
+        composer
+            .add_composable_module(ComposableModuleDescriptor {
+                source: include_str!("tests/big_shaderdefs/mod.wgsl"),
+                file_path: "tests/big_shaderdefs/mod.wgsl",
+                ..Default::default()
+            })
+            .unwrap();
+
+        let defs = (1..=67).map(|i| format!("a{}", i)).collect::<Vec<String>>();
+
+        let module = composer
+            .make_naga_module(NagaModuleDescriptor {
+                source: include_str!("tests/big_shaderdefs/top.wgsl"),
+                file_path: "tests/big_shaderdefs/top.wgsl",
+                shader_defs: &defs,
+                ..Default::default()
+            })
+            .unwrap();
+
+        let info = naga::valid::Validator::new(
+            naga::valid::ValidationFlags::all(),
+            naga::valid::Capabilities::default(),
+        )
+        .validate(&module)
+        .unwrap();
+        let wgsl = naga::back::wgsl::write_string(
+            &module,
+            &info,
+            naga::back::wgsl::WriterFlags::EXPLICIT_TYPES,
+        )
+        .unwrap();
+
+        // println!("{}", wgsl);
+        // let mut f = std::fs::File::create("big_shaderdefs.txt").unwrap();
+        // f.write_all(wgsl.as_bytes()).unwrap();
+        // drop(f);
+
+        assert_eq!(wgsl, include_str!("tests/expected/big_shaderdefs.txt"));
+    }
+
+    #[test]
     fn duplicate_import() {
         let mut composer = Composer::default();
 

--- a/src/compose/tests/big_shaderdefs/mod.wgsl
+++ b/src/compose/tests/big_shaderdefs/mod.wgsl
@@ -1,0 +1,144 @@
+#define_import_path mod
+
+fn f() -> f32 {
+    var x = 0.0;
+#ifdef a1
+#ifdef a2
+#ifdef a3
+#ifdef a4
+#ifdef a5
+#ifdef a6
+#ifdef a7
+#ifdef a8
+#ifdef a9
+#ifdef a10
+#ifdef a11
+#ifdef a12
+#ifdef a13
+#ifdef a14
+#ifdef a15
+#ifdef a16
+#ifdef a17
+#ifdef a18
+#ifdef a19
+#ifdef a20
+#ifdef a21
+#ifdef a22
+#ifdef a23
+#ifdef a24
+#ifdef a25
+#ifdef a26
+#ifdef a27
+#ifdef a28
+#ifdef a29
+#ifdef a30
+#ifdef a31
+#ifdef a32
+#ifdef a33
+#ifdef a34
+#ifdef a35
+#ifdef a36
+#ifdef a37
+#ifdef a38
+#ifdef a39
+#ifdef a40
+#ifdef a41
+#ifdef a42
+#ifdef a43
+#ifdef a44
+#ifdef a45
+#ifdef a46
+#ifdef a47
+#ifdef a48
+#ifdef a49
+#ifdef a50
+#ifdef a51
+#ifdef a52
+#ifdef a53
+#ifdef a54
+#ifdef a55
+#ifdef a56
+#ifdef a57
+#ifdef a58
+#ifdef a59
+#ifdef a60
+#ifdef a61
+#ifdef a62
+#ifdef a63
+#ifdef a64
+#ifdef a65
+#ifdef a66
+#ifdef a66
+#ifdef a67
+    x = 1.0;
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+    return x;
+}
+

--- a/src/compose/tests/big_shaderdefs/top.wgsl
+++ b/src/compose/tests/big_shaderdefs/top.wgsl
@@ -1,0 +1,5 @@
+#import mod
+
+fn main() -> f32 {
+    return mod::f();
+}

--- a/src/compose/tests/expected/big_shaderdefs.txt
+++ b/src/compose/tests/expected/big_shaderdefs.txt
@@ -1,0 +1,13 @@
+fn _naga_oil__mod__NVXWI__member__f() -> f32 {
+    var x: f32 = 0.0;
+
+    x = 1.0;
+    let _e3: f32 = x;
+    return _e3;
+}
+
+fn main() -> f32 {
+    let _e0: f32 = _naga_oil__mod__NVXWI__member__f();
+    return _e0;
+}
+


### PR DESCRIPTION
fix #1 by using a `BitSet` for the module key instead of a `usize`. this dependency is in naga already.

might be a better way to do this that avoids allocating, but it should at least be correct now for larger sets of shader defs.