### PR TITLE
rescope imported constants

### DIFF
--- a/src/compose/test.rs
+++ b/src/compose/test.rs
@@ -507,6 +507,54 @@ mod test {
         assert_eq!(test_shader(&mut composer), 2.0);
     }
 
+    #[test]
+    fn import_in_decl() {
+        let mut composer = Composer::default();
+        composer
+            .add_composable_module(ComposableModuleDescriptor {
+                source: include_str!("tests/const_in_decl/consts.wgsl"),
+                file_path: "tests/const_in_decl/consts.wgsl",
+                ..Default::default()
+            })
+            .unwrap();
+        composer
+            .add_composable_module(ComposableModuleDescriptor {
+                source: include_str!("tests/const_in_decl/bind.wgsl"),
+                file_path: "tests/const_in_decl/bind.wgsl",
+                ..Default::default()
+            })
+            .unwrap();
+        let module = composer
+            .make_naga_module(NagaModuleDescriptor {
+                source: include_str!("tests/const_in_decl/top.wgsl"),
+                file_path: "tests/const_in_decl/top.wgsl",
+                ..Default::default()
+            })
+            .unwrap();
+
+        println!("{:#?}", module);
+
+        let info = naga::valid::Validator::new(
+            naga::valid::ValidationFlags::all(),
+            naga::valid::Capabilities::default(),
+        )
+        .validate(&module)
+        .unwrap();
+        let wgsl = naga::back::wgsl::write_string(
+            &module,
+            &info,
+            naga::back::wgsl::WriterFlags::EXPLICIT_TYPES,
+        )
+        .unwrap();
+
+        // println!("{}", wgsl);
+        // let mut f = std::fs::File::create("import_in_decl.txt").unwrap();
+        // f.write_all(wgsl.as_bytes()).unwrap();
+        // drop(f);
+
+        assert_eq!(wgsl, include_str!("tests/expected/import_in_decl.txt"));
+    }
+
     // actually run a shader and extract the result
     // needs the composer to contain a module called "test_module", with a function called "entry_point" returning an f32.
     fn test_shader(composer: &mut Composer) -> f32 {

--- a/src/compose/tests/const_in_decl/bind.wgsl
+++ b/src/compose/tests/const_in_decl/bind.wgsl
@@ -1,0 +1,7 @@
+#define_import_path bind
+
+#import consts
+
+let y: u32 = 2u;
+
+var<private> arr: array<u32, consts::X>;

--- a/src/compose/tests/const_in_decl/consts.wgsl
+++ b/src/compose/tests/const_in_decl/consts.wgsl
@@ -1,0 +1,3 @@
+#define_import_path consts
+
+let X: u32 = 1u;

--- a/src/compose/tests/const_in_decl/top.wgsl
+++ b/src/compose/tests/const_in_decl/top.wgsl
@@ -1,0 +1,6 @@
+#import consts
+#import bind
+
+fn main() -> f32 {
+    return f32(bind::arr[0]);
+} 

--- a/src/compose/tests/expected/import_in_decl.txt
+++ b/src/compose/tests/expected/import_in_decl.txt
@@ -1,0 +1,13 @@
+let _naga_oil__mod__MNXW443UOM__member__X: u32 = 1u;
+
+let _naga_oil__mod__MJUW4ZA__member__y: u32 = 2u;
+
+let _naga_oil__mod__MJUW4ZA__member___naga_oil__mod__MNXW443UOM__member__X: u32 = 1u;
+
+var<private> _naga_oil__mod__MJUW4ZA__member__arr: array<u32,_naga_oil__mod__MJUW4ZA__member___naga_oil__mod__MNXW443UOM__member__X>;
+
+fn main() -> f32 {
+    let _e6: u32 = _naga_oil__mod__MJUW4ZA__member__arr[0];
+    return f32(_e6);
+}
+


### PR DESCRIPTION
when imported constants are used in headers, rescope them to the current module.

this may have unintended consequences, according to https://www.w3.org/TR/WGSL/#array-types (the example section headed "EXAMPLE: Workgroup variables sized by overridable constants"), workgroup arrays using different but equal `override` source variables for the size will no longer have the same type. 

i'm not sure if there are any significant consequences to that (or even if `override` declarations are actually treated as consts).