### PR TITLE
bump naga version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 prune = ["dep:serde", "dep:serde_json", "naga/deserialize", "naga/serialize"]
 
 [dependencies]
-naga = { version = "0.9", features = ["wgsl-in", "wgsl-out", "glsl-in", "glsl-out"] }
+naga = { version = "0.10", features = ["wgsl-in", "wgsl-out", "glsl-in", "glsl-out"] }
 tracing = "0.1"
 regex = "1.5"
 regex-syntax = "0.6"
@@ -25,6 +25,6 @@ serde = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }
 
 [dev-dependencies]
-wgpu = { version = "0.13", features=["naga"] }
+wgpu = { version = "0.14", features=["naga"] }
 futures-lite = "1"
 tracing-subscriber = { version = "0.3", features = ["std", "fmt"] }

--- a/examples/pbr_compose_test.rs
+++ b/examples/pbr_compose_test.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use naga_oil::compose::{
     ComposableModuleDescriptor, Composer, ComposerError, NagaModuleDescriptor,
 };
@@ -181,7 +183,7 @@ fn test_composer_compile(n: usize, composer: &mut Composer) {
             })
             .unwrap();
         let _desc = device.create_shader_module(wgpu::ShaderModuleDescriptor {
-            source: wgpu::ShaderSource::Naga(module),
+            source: wgpu::ShaderSource::Naga(Cow::Owned(module)),
             label: None,
         });
     }

--- a/src/compose/mod.rs
+++ b/src/compose/mod.rs
@@ -960,8 +960,21 @@ impl Composer {
                 ));
                 let header_function = naga::Function {
                     name: ep.function.name.clone(),
-                    arguments: ep.function.arguments.to_vec(),
-                    result: ep.function.result.clone(),
+                    arguments: ep
+                        .function
+                        .arguments
+                        .iter()
+                        .cloned()
+                        .map(|arg| naga::FunctionArgument {
+                            name: arg.name,
+                            ty: arg.ty,
+                            binding: None,
+                        })
+                        .collect(),
+                    result: ep.function.result.clone().map(|res| naga::FunctionResult {
+                        ty: res.ty,
+                        binding: None,
+                    }),
                     local_variables: Default::default(),
                     expressions: Default::default(),
                     named_expressions: Default::default(),
@@ -1020,7 +1033,22 @@ impl Composer {
         // // including entry points as vanilla functions if required
         if demote_entrypoints {
             for ep in source_ir.entry_points.iter() {
-                module_builder.import_function(&ep.function, naga::Span::UNDEFINED);
+                let mut f = ep.function.clone();
+                f.arguments = f
+                    .arguments
+                    .into_iter()
+                    .map(|arg| naga::FunctionArgument {
+                        name: arg.name,
+                        ty: arg.ty,
+                        binding: None,
+                    })
+                    .collect();
+                f.result = f.result.map(|res| naga::FunctionResult {
+                    ty: res.ty,
+                    binding: None,
+                });
+
+                module_builder.import_function(&f, naga::Span::UNDEFINED);
                 // todo figure out how to get span info for entrypoints
             }
         }

--- a/src/compose/tests/expected/err_validation_1.txt
+++ b/src/compose/tests/expected/err_validation_1.txt
@@ -1,14 +1,10 @@
 [0m[1m[38;5;9merror[0m[1m: failed to build a valid final module: Function [2] 'func' is invalid[0m
-  [0m[36m┌─[0m tests/error_test/wgsl_valid_err.wgsl:5:2
+  [0m[36m┌─[0m tests/error_test/wgsl_valid_err.wgsl:7:1
   [0m[36m│[0m  
-[0m[36m5[0m [0m[36m│[0m   }
-  [0m[36m│[0m [0m[31m╭[0m[0m[31m─^[0m
-[0m[36m6[0m [0m[36m│[0m [0m[31m│[0m 
-[0m[36m7[0m [0m[36m│[0m [0m[31m│[0m [0m[31mfn func() -> f32 {[0m
+[0m[36m7[0m [0m[36m│[0m [0m[31m╭[0m [0m[31mfn func() -> f32 {[0m
 [0m[36m8[0m [0m[36m│[0m [0m[31m│[0m [0m[31m    return 1u;[0m
-  [0m[36m│[0m [0m[31m│[0m           [0m[31m^^^[0m [0m[31mnaga::Expression [1][0m
-[0m[36m9[0m [0m[36m│[0m [0m[31m│[0m [0m[31m}[0m
-  [0m[36m│[0m [0m[31m╰[0m[0m[31m─^ naga::Function [2][0m
+  [0m[36m│[0m [0m[31m│[0m            [0m[31m^^[0m [0m[31mnaga::Expression [1][0m
+  [0m[36m│[0m [0m[31m╰[0m[0m[31m──────────────^ naga::Function [2][0m
   [0m[36m│[0m  
   [0m[36m=[0m The `return` value Some([1]) does not match the function return value
 

--- a/src/compose/tests/expected/err_validation_2.txt
+++ b/src/compose/tests/expected/err_validation_2.txt
@@ -1,14 +1,10 @@
 [0m[1m[38;5;9merror[0m[1m: failed to build a valid final module: Function [2] 'valid_inc::func' is invalid[0m
-  [0m[36m┌─[0m tests/error_test/wgsl_valid_err.wgsl:5:2
+  [0m[36m┌─[0m tests/error_test/wgsl_valid_err.wgsl:7:1
   [0m[36m│[0m  
-[0m[36m5[0m [0m[36m│[0m   }
-  [0m[36m│[0m [0m[31m╭[0m[0m[31m─^[0m
-[0m[36m6[0m [0m[36m│[0m [0m[31m│[0m 
-[0m[36m7[0m [0m[36m│[0m [0m[31m│[0m [0m[31mfn func() -> f32 {[0m
+[0m[36m7[0m [0m[36m│[0m [0m[31m╭[0m [0m[31mfn func() -> f32 {[0m
 [0m[36m8[0m [0m[36m│[0m [0m[31m│[0m [0m[31m    return 1u;[0m
-  [0m[36m│[0m [0m[31m│[0m           [0m[31m^^^[0m [0m[31mnaga::Expression [1][0m
-[0m[36m9[0m [0m[36m│[0m [0m[31m│[0m [0m[31m}[0m
-  [0m[36m│[0m [0m[31m╰[0m[0m[31m─^ naga::Function [2][0m
+  [0m[36m│[0m [0m[31m│[0m            [0m[31m^^[0m [0m[31mnaga::Expression [1][0m
+  [0m[36m│[0m [0m[31m╰[0m[0m[31m──────────────^ naga::Function [2][0m
   [0m[36m│[0m  
   [0m[36m=[0m The `return` value Some([1]) does not match the function return value
 

--- a/src/compose/tests/expected/wgsl_call_entrypoint.txt
+++ b/src/compose/tests/expected/wgsl_call_entrypoint.txt
@@ -2,7 +2,7 @@ fn _naga_oil__mod__NFXGG3DVMRSQ__member__non_ep(f: f32) -> f32 {
     return (f * 2.0);
 }
 
-fn _naga_oil__mod__NFXGG3DVMRSQ__member__fragment(@builtin(position) frag_coord_1: vec4<f32>) -> @location(0) vec4<f32> {
+fn _naga_oil__mod__NFXGG3DVMRSQ__member__fragment(frag_coord_1: vec4<f32>) -> vec4<f32> {
     return vec4<f32>(1.0);
 }
 


### PR DESCRIPTION
update naga to 0.10
update wgpu to 0.14

compose:
- remove `@location`/`@builtin` bindings from demoted entrypoints (this was previously incorrect but not an error)

in tests:
- update expected output
- use `Cow` for passing modules to wgpu.
- require MAPPABLE_PRIMARY_BUFFERS feature for gpu testing
